### PR TITLE
Fix reports workflow commit step output

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -104,9 +104,16 @@ jobs:
           git add data/reports/
           git add photos.json
 
-          # Get the date from the most recent report
-          REPORT_DATE=$(ls -t data/reports/*/*.json | head -n 1 | xargs basename .json)
-          GRADE=$(jq -r '.grade' "data/reports/${REPORT_DATE:0:4}/${REPORT_DATE}.json")
+          # Get the date from the most recent report (sort by name for predictable ordering)
+          REPORT_FILE=$(ls data/reports/*/*.json | sort -r | head -n 1)
+
+          if [ -z "$REPORT_FILE" ]; then
+            echo "Error: No report files found"
+            exit 1
+          fi
+
+          REPORT_DATE=$(basename "$REPORT_FILE" .json)
+          GRADE=$(jq -r '.grade' "$REPORT_FILE")
 
           git commit -m "$(cat <<EOF
           Add report card for ${REPORT_DATE} (Grade: ${GRADE})
@@ -127,7 +134,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           # Get the date from the most recent report
-          REPORT_DATE=$(ls -t data/reports/*/*.json | head -n 1 | xargs basename .json)
+          REPORT_FILE=$(ls data/reports/*/*.json | sort -r | head -n 1)
+          REPORT_DATE=$(basename "$REPORT_FILE" .json)
           echo "Sending Slack notification for report: ${REPORT_DATE}"
           bun run scripts/notifications/slack-notify.ts --date "${REPORT_DATE}"
 
@@ -137,7 +145,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get the date from the most recent report
-          REPORT_DATE=$(ls -t data/reports/*/*.json | head -n 1 | xargs basename .json)
+          REPORT_FILE=$(ls data/reports/*/*.json | sort -r | head -n 1)
+          REPORT_DATE=$(basename "$REPORT_FILE" .json)
           echo "Creating GitHub Issue for report: ${REPORT_DATE}"
           bun run scripts/notifications/github-issue-notify.ts --date "${REPORT_DATE}"
 


### PR DESCRIPTION
The previous implementation used `xargs basename .json` which doesn't properly pass the suffix argument to basename, causing it to fail with malformed paths like "data/reports/.jso/.json.json".

Changes:
- Store full path in REPORT_FILE variable first
- Use proper basename syntax: basename "$REPORT_FILE" .json
- Switch from ls -t (sort by mtime) to sort -r (sort by name descending) for more predictable ordering
- Add error checking to ensure REPORT_FILE is not empty
- Apply same fix to Slack and GitHub Issue notification steps

This fixes the "Could not open file data/reports/.jso/.json.json" error that was preventing commits from succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)