### PR TITLE
Fix truncated text in Slack report notification

### DIFF
--- a/scripts/notifications/slack-notify.ts
+++ b/scripts/notifications/slack-notify.ts
@@ -82,17 +82,14 @@ function formatSlackMessage(
   const gradeEmoji = GRADE_EMOJI[report.grade] || '📝';
 
   // Format activities into readable list
-  const activities = report.whatIDidToday.slice(0, 5).join(', ');
   const activitiesText =
     report.whatIDidToday.length > 0
-      ? report.whatIDidToday.length > 5
-        ? `${activities}, and more...`
-        : activities
+      ? report.whatIDidToday.join(', ')
       : 'None today';
 
   // Format training skills
   const trainingText =
-    report.trainingSkills.length > 0 ? report.trainingSkills.slice(0, 3).join(', ') : 'None today';
+    report.trainingSkills.length > 0 ? report.trainingSkills.join(', ') : 'None today';
 
   // Best part of day
   const bestPart = report.bestPartOfDay;


### PR DESCRIPTION
- Show all activities in 'What I Did Today' (was truncated at 5)
- Show all training skills (was truncated at 3)
- Remove 'and more...' suffix from activities